### PR TITLE
Update Blazor.SourceGenerators.csproj

### DIFF
--- a/src/Blazor.SourceGenerators/Blazor.SourceGenerators.csproj
+++ b/src/Blazor.SourceGenerators/Blazor.SourceGenerators.csproj
@@ -53,6 +53,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IsPackable>true</IsPackable>
         <PackageIcon>logo.png</PackageIcon>
+        <developmentDependency>true</developmentDependency>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -71,7 +72,7 @@
     <ItemGroup>
         <!-- Package the generator in the analyzer directory of the nuget package -->
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-       </ItemGroup>
+    </ItemGroup>
     
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">


### PR DESCRIPTION
The developmentDependency is needed for the Analyzer to show up. I believe this fixes #15.