### PR TITLE
Replaced `invokeMethod` with `invokeMethodAsync`

### DIFF
--- a/src/Blazor.Geolocation/wwwroot/blazorators.geolocation.g.js
+++ b/src/Blazor.Geolocation/wwwroot/blazorators.geolocation.g.js
@@ -16,7 +16,7 @@ const onSuccess = (dotnetObj, successMethodName, position) => {
             Speed: position.coords.speed
         }
     };
-    dotnetObj.invokeMethod(successMethodName, result);
+    dotnetObj.invokeMethodAsync(successMethodName, result);
     dotnetObj.dispose();
 };
 
@@ -28,7 +28,7 @@ const onError = (dotnetObj, errorMethodName, error) => {
         POSITION_UNAVAILABLE: error.POSITION_UNAVAILABLE,
         TIMEOUT: error.TIMEOUT
     };
-    dotnetObj.invokeMethod(errorMethodName, result);
+    dotnetObj.invokeMethodAsync(errorMethodName, result);
     dotnetObj.dispose();
 };
 
@@ -37,22 +37,22 @@ const getCurrentPosition = (
     successMethodName,
     errorMethodName,
     options) => {
-    navigator.geolocation.getCurrentPosition(
-        position => onSuccess(dotnetObj, successMethodName, position),
-        error => onError(dotnetObj, errorMethodName, error),
-        options);
-}
+        navigator.geolocation.getCurrentPosition(
+            position => onSuccess(dotnetObj, successMethodName, position),
+            error => onError(dotnetObj, errorMethodName, error),
+            options);
+    }
 
 const watchPosition = (
     dotnetObj,
     successMethodName,
     errorMethodName,
     options) => {
-    return navigator.geolocation.watchPosition(
-        position => onSuccess(dotnetObj, successMethodName, position),
-        error => onError(dotnetObj, errorMethodName, error),
-        options);
-}
+        return navigator.geolocation.watchPosition(
+            position => onSuccess(dotnetObj, successMethodName, position),
+            error => onError(dotnetObj, errorMethodName, error),
+            options);
+    }
 
 window.blazorators = Object.assign({}, window.blazorators, {
     geolocation: {


### PR DESCRIPTION
Using `invokeMethod` throws the following error -
```
Uncaught Error: The current dispatcher does not support synchronous calls from JS to .NET. Use invokeMethodAsync instead.
    at y (blazor.server.js:1:1840)
    at C.invokeMethod (blazor.server.js:1:3960)
    at onSuccess (geolocation.js:19:15)
    at geolocation.js:41:25
```

This issue can be overcome by using the async method.