### PR TITLE
Fix resilient docs startup and CI

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,6 +1,7 @@
 name: build and test
 
 on:
+  workflow_call:
   push:
     branches: [ main ]
     paths-ignore:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,9 +6,14 @@ on:
     branches: [ main ]
     paths:
     - '**.cs'
+    - '**.razor'
+    - '**.html'
+    - '**.css'
+    - '**.js'
     - '**.json'
     - '**.csproj'
     - '**.sln'
+    - '.github/workflows/**'
 
 jobs:
   validate:

--- a/samples/Blazor.ExampleConsumer/Components/Pages/Home.razor
+++ b/samples/Blazor.ExampleConsumer/Components/Pages/Home.razor
@@ -286,11 +286,6 @@
         }
     }
 
-    protected override void OnInitialized()
-    {
-        _typewriterTask = RunTypewriterAsync(_typewriterCts.Token);
-    }
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender)
@@ -298,14 +293,21 @@
             return;
         }
 
+        var prefersReducedMotion = false;
         try
         {
             _spotlight = await JS.InvokeAsync<IJSObjectReference>("import", "./spotlight.js");
+            prefersReducedMotion = await _spotlight.InvokeAsync<bool>("isReducedMotionPreferred");
             await _spotlight.InvokeVoidAsync("init", ".bento");
         }
-        catch
+        catch (JSException)
         {
-            // Spotlight is purely decorative — never fail the page on its account.
+            // Hero motion and spotlight are decorative — never fail the page on their account.
+        }
+
+        if (!prefersReducedMotion)
+        {
+            _typewriterTask = RunTypewriterAsync(_typewriterCts.Token);
         }
     }
 

--- a/samples/Blazor.ExampleConsumer/wwwroot/index.html
+++ b/samples/Blazor.ExampleConsumer/wwwroot/index.html
@@ -60,6 +60,65 @@
 
     <script src="_content/Blazor.Geolocation.WebAssembly/blazorators.geolocation.g.js"></script>
     <script src="_content/Blazor.SpeechSynthesis.WebAssembly/blazorators.speechSynthesis.g.js"></script>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+    <script>
+        (() => {
+            const retryableStatusCodes = new Set([408, 429, 500, 502, 503, 504]);
+            const maxBootResourceAttempts = 3;
+            const errorUi = document.getElementById('blazor-error-ui');
+
+            errorUi.querySelector('.reload').addEventListener('click', () => location.reload());
+            errorUi.querySelector('.dismiss').addEventListener('click', () => {
+                errorUi.hidden = true;
+                errorUi.style.removeProperty('display');
+            });
+
+            function loadBootResource(_type, _name, defaultUri, integrity) {
+                if (_type === 'dotnetjs') {
+                    return defaultUri;
+                }
+
+                return fetchBootResourceWithRetry(defaultUri, integrity);
+            }
+
+            async function fetchBootResourceWithRetry(defaultUri, integrity) {
+                for (let attempt = 1; attempt <= maxBootResourceAttempts; attempt++) {
+                    const uri = new URL(defaultUri, document.baseURI);
+                    if (attempt > 1) {
+                        uri.searchParams.set('blazor-retry', `${attempt - 1}-${Date.now()}`);
+                    }
+
+                    const requestOptions = {
+                        cache: attempt === 1 ? 'default' : 'reload'
+                    };
+                    if (integrity) {
+                        requestOptions.integrity = integrity;
+                    }
+
+                    try {
+                        const response = await fetch(uri, requestOptions);
+                        if (response.ok ||
+                            !retryableStatusCodes.has(response.status) ||
+                            attempt === maxBootResourceAttempts) {
+                            return response;
+                        }
+                    } catch (error) {
+                        if (attempt === maxBootResourceAttempts) {
+                            throw error;
+                        }
+                    }
+
+                    await new Promise(resolve =>
+                        setTimeout(resolve, 200 * 2 ** (attempt - 1)));
+                }
+            }
+
+            Blazor.start({ loadBootResource }).catch(error => {
+                console.error('Blazor failed to start.', error);
+                errorUi.hidden = false;
+                errorUi.style.display = 'flex';
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/samples/Blazor.ExampleConsumer/wwwroot/spotlight.js
+++ b/samples/Blazor.ExampleConsumer/wwwroot/spotlight.js
@@ -70,3 +70,7 @@ export function init(scopeSelector) {
     }
     return cards.length;
 }
+
+export function isReducedMotionPreferred() {
+    return prefersReducedMotion.matches;
+}

--- a/tests/Blazor.ExampleConsumer.EndToEndTests/ExampleSiteTests.cs
+++ b/tests/Blazor.ExampleConsumer.EndToEndTests/ExampleSiteTests.cs
@@ -208,38 +208,55 @@ public sealed class ExampleSiteTests(
                 () => {
                     const rotator = document.querySelector('.word-rotator');
                     const rotatorRect = rotator.getBoundingClientRect();
-                    const visible = [...rotator.querySelectorAll('span')]
+                    const fragments = [...rotator.children]
+                        .filter(span => span.getAttribute('aria-hidden') !== 'true')
                         .map(span => {
                             const style = getComputedStyle(span);
                             const rect = span.getBoundingClientRect();
                             return {
-                                opacity: Number.parseFloat(style.opacity),
+                                label: span.textContent.trim() || span.className,
+                                display: style.display,
+                                visibility: style.visibility,
+                                left: rect.left,
+                                right: rect.right,
                                 top: rect.top,
                                 bottom: rect.bottom,
                                 width: rect.width,
-                                text: span.textContent.trim()
+                                height: rect.height
                             };
                         })
-                        .filter(span => span.opacity > 0.05);
+                        .filter(span =>
+                            span.display !== 'none' &&
+                            span.visibility !== 'hidden' &&
+                            span.width > 0 &&
+                            span.height > 0);
 
                     return {
-                        visibleCount: visible.length,
                         rotatorTop: rotatorRect.top,
                         rotatorBottom: rotatorRect.bottom,
                         rotatorWidth: rotatorRect.width,
-                        visible
+                        fragments
                     };
                 }
                 """);
 
-            Assert.InRange(result.VisibleCount, 0, 1);
             Assert.True(result.RotatorWidth > 0, "The word rotator should reserve width for the active word.");
+            Assert.InRange(result.Fragments.Length, 0, 2);
 
-            foreach (var span in result.Visible)
+            foreach (var fragment in result.Fragments)
             {
-                Assert.True(span.Top >= result.RotatorTop - 1, $"Rotating word '{span.Text}' is clipped above its container.");
-                Assert.True(span.Bottom <= result.RotatorBottom + 1, $"Rotating word '{span.Text}' is clipped below its container.");
-                Assert.True(span.Width <= result.RotatorWidth + 1, $"Rotating word '{span.Text}' is wider than its reserved container.");
+                Assert.True(fragment.Top >= result.RotatorTop - 2, $"Typewriter fragment '{fragment.Label}' is clipped above its container.");
+                Assert.True(fragment.Bottom <= result.RotatorBottom + 2, $"Typewriter fragment '{fragment.Label}' is clipped below its container.");
+                Assert.True(fragment.Width <= result.RotatorWidth + 1, $"Typewriter fragment '{fragment.Label}' is wider than its reserved container.");
+            }
+
+            for (var fragmentIndex = 1; fragmentIndex < result.Fragments.Length; fragmentIndex++)
+            {
+                var previous = result.Fragments[fragmentIndex - 1];
+                var current = result.Fragments[fragmentIndex];
+                Assert.True(
+                    previous.Right <= current.Left + 1,
+                    $"Typewriter fragments '{previous.Label}' and '{current.Label}' overlap.");
             }
 
             await Task.Delay(300);
@@ -254,25 +271,65 @@ public sealed class ExampleSiteTests(
         await page.GotoAsync(site.UrlFor("/"));
         await ExpectHeadingAsync(page, "Browser APIs");
 
-        var snapshot = await page.EvaluateAsync<ReducedMotionSnapshot>(
+        static Task<ReducedMotionSnapshot> ReadSnapshotAsync(IPage page) =>
+            page.EvaluateAsync<ReducedMotionSnapshot>(
             """
             () => {
-                const words = [...document.querySelectorAll('.word-rotator > span')]
-                    .map(span => ({
-                        text: span.textContent.trim(),
-                        opacity: Number.parseFloat(getComputedStyle(span).opacity),
-                        animationName: getComputedStyle(span).animationName
-                    }));
+                const rotator = document.querySelector('.word-rotator');
 
                 return {
-                    visibleWords: words.filter(word => word.opacity > 0.9).map(word => word.text),
-                    animationNames: words.map(word => word.animationName)
+                    phrase: rotator.getAttribute('aria-label'),
+                    animationNames: [...rotator.children]
+                        .map(span => getComputedStyle(span).animationName)
                 };
             }
             """);
 
-        Assert.Equal(new[] { "type-safe" }, snapshot.VisibleWords);
-        Assert.All(snapshot.AnimationNames, animationName => Assert.Equal("none", animationName));
+        var initial = await ReadSnapshotAsync(page);
+        await Task.Delay(2_000);
+        var afterHold = await ReadSnapshotAsync(page);
+
+        Assert.Equal("type-safe in C#.", initial.Phrase);
+        Assert.Equal(initial.Phrase, afterHold.Phrase);
+        Assert.All(initial.AnimationNames, animationName => Assert.Equal("none", animationName));
+        Assert.All(afterHold.AnimationNames, animationName => Assert.Equal("none", animationName));
+    }
+
+    [Fact]
+    public async Task BootResourceLoader_RetriesCachedTransientFailures()
+    {
+        await using var context = await NewContextAsync();
+        var page = await context.NewPageAsync();
+        var requestUrls = new List<string>();
+
+        await page.RouteAsync(
+            "**/_framework/Microsoft.Extensions.Logging.Abstractions*.wasm*",
+            async route =>
+            {
+                requestUrls.Add(route.Request.Url);
+                if (!new Uri(route.Request.Url).Query.Contains("blazor-retry=", StringComparison.Ordinal))
+                {
+                    await route.FulfillAsync(new RouteFulfillOptions
+                    {
+                        Status = 503,
+                        ContentType = "text/plain",
+                        Body = "Service Unavailable"
+                    });
+                    return;
+                }
+
+                await route.ContinueAsync();
+            });
+
+        await page.GotoAsync(site.UrlFor("/"), new PageGotoOptions
+        {
+            WaitUntil = WaitUntilState.NetworkIdle
+        });
+
+        await ExpectHeadingAsync(page, "Browser APIs");
+        Assert.Contains(
+            requestUrls,
+            url => new Uri(url).Query.Contains("blazor-retry=", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -452,25 +509,25 @@ public sealed class ExampleSiteTests(
 
     sealed class RotatorSnapshot
     {
-        public int VisibleCount { get; set; }
         public double RotatorTop { get; set; }
         public double RotatorBottom { get; set; }
         public double RotatorWidth { get; set; }
-        public RotatorWordSnapshot[] Visible { get; set; } = [];
+        public RotatorFragmentSnapshot[] Fragments { get; set; } = [];
     }
 
-    sealed class RotatorWordSnapshot
+    sealed class RotatorFragmentSnapshot
     {
-        public double Opacity { get; set; }
+        public string Label { get; set; } = "";
+        public double Left { get; set; }
+        public double Right { get; set; }
         public double Top { get; set; }
         public double Bottom { get; set; }
         public double Width { get; set; }
-        public string Text { get; set; } = "";
     }
 
     sealed class ReducedMotionSnapshot
     {
-        public string[] VisibleWords { get; set; } = [];
+        public string Phrase { get; set; } = "";
         public string[] AnimationNames { get; set; } = [];
     }
 


### PR DESCRIPTION
## Summary

- Retry transient Blazor boot-resource failures with cache-busting URLs while preserving SRI validation.
- Surface a usable startup error UI if retries are exhausted.
- Honor `prefers-reduced-motion` in the C# hero typewriter and update its stale layout assertions.
- Add an end-to-end regression that reproduces the cached GitHub Pages `503` seen for the logging abstractions WASM asset.
- Repair the reusable PR validation workflow and ensure sample-site assets trigger it.

## Validation

- `dotnet test tests/Blazor.ExampleConsumer.EndToEndTests/Blazor.ExampleConsumer.EndToEndTests.csproj --verbosity normal` — 23 passed
- Release publish matching the Pages workflow, including published boot-loader and WASM asset checks
- Hosted PR validation — all 12 build matrix jobs and the test job passed